### PR TITLE
Settings: Hide unsupported USB modes automatically

### DIFF
--- a/src/com/android/settings/connecteddevice/usb/UsbBackend.java
+++ b/src/com/android/settings/connecteddevice/usb/UsbBackend.java
@@ -159,6 +159,30 @@ public class UsbBackend {
                 && mPortStatus.isRoleCombinationSupported(POWER_ROLE_SOURCE, DATA_ROLE_HOST);
     }
 
+    public boolean isSingleDataRoleSupported() {
+        return mPort != null && mPortStatus != null
+                && ((!mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SINK, DATA_ROLE_HOST)
+                && !mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SOURCE, DATA_ROLE_HOST))
+                || (!mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SINK, DATA_ROLE_DEVICE)
+                && !mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SOURCE, DATA_ROLE_DEVICE)));
+    }
+
+    public boolean isSinglePowerRoleSupported() {
+        return mPort != null && mPortStatus != null
+                && ((!mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SINK, DATA_ROLE_DEVICE)
+                && !mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SINK, DATA_ROLE_HOST))
+                || (!mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SOURCE, DATA_ROLE_DEVICE)
+                && !mPortStatus
+                .isRoleCombinationSupported(POWER_ROLE_SOURCE, DATA_ROLE_HOST)));
+    }
+
     public static String usbFunctionsToString(long functions) {
         // TODO replace with UsbManager.usbFunctionsToString once supported by Roboelectric
         return Long.toBinaryString(functions);

--- a/src/com/android/settings/connecteddevice/usb/UsbDetailsDataRoleController.java
+++ b/src/com/android/settings/connecteddevice/usb/UsbDetailsDataRoleController.java
@@ -113,7 +113,8 @@ public class UsbDetailsDataRoleController extends UsbDetailsController
 
     @Override
     public boolean isAvailable() {
-        return !Utils.isMonkeyRunning();
+        return !Utils.isMonkeyRunning()
+                && !mUsbBackend.isSingleDataRoleSupported();
     }
 
     @Override

--- a/src/com/android/settings/connecteddevice/usb/UsbDetailsPowerRoleController.java
+++ b/src/com/android/settings/connecteddevice/usb/UsbDetailsPowerRoleController.java
@@ -123,7 +123,8 @@ public class UsbDetailsPowerRoleController extends UsbDetailsController
 
     @Override
     public boolean isAvailable() {
-        return !Utils.isMonkeyRunning();
+        return !Utils.isMonkeyRunning()
+                && !mUsbBackend.isSinglePowerRoleSupported();
     }
 
     @Override


### PR DESCRIPTION
 * The roles are advertised by USB HAL so we can check for their status

Change-Id: I5933d1a03f573af08b00039850173329b293448a
(cherry picked from commit b4468d815f0d831bbd6f69eac103d5902053daa7)